### PR TITLE
chore: add missing class

### DIFF
--- a/javascripts/discourse/connectors/users-top/add-nav.hbs
+++ b/javascripts/discourse/connectors/users-top/add-nav.hbs
@@ -1,3 +1,3 @@
-<div class="list-controls clearfix">
+<div class="list-controls navigation-container clearfix">
   {{d-navigation filterMode="users"}}
 </div>


### PR DESCRIPTION
The rest of the Discourse pages seem to have `navigation-container` as a class of the navbar component.  Because this component modifies the navbar and the /users page doesn't have one, it should probably be the element to contain this class. 

Context: https://github.com/freeCodeCamp/forum-theme/issues/125