### PR TITLE
chore: only allow pnpm to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "preinstall": "npx only-allow pnpm"
+  },
   "devDependencies": {
     "@discourse/lint-configs": "1.4.2",
     "ember-template-lint": "6.0.0",
@@ -9,8 +12,6 @@
   },
   "engines": {
     "node": ">= 18",
-    "npm": "please-use-pnpm",
-    "yarn": "please-use-pnpm",
     "pnpm": ">= 9"
   }
 }


### PR DESCRIPTION
It was bugging me that you were avoiding a very simple readily available solution to enforce `pnpm`. 